### PR TITLE
fix:pnpm filter command fixed

### DIFF
--- a/build/gulpfile.ts
+++ b/build/gulpfile.ts
@@ -22,7 +22,7 @@ export default series(
     withTaskName("clean", async () => run('rm -rf ./dist')),
     parallel(
         withTaskName("buildPackages", () =>
-            run("pnpm run --filter ./packages --parallel build")
+            run("pnpm run --filter ./packages/* --parallel build")
         ),
         withTaskName("buildFullComponent", () =>
             run("pnpm run build buildFullComponent")


### PR DESCRIPTION
修复执行pnpm run --filter时无法匹配依赖包的问题